### PR TITLE
Upgrade OpenSearch to 2.4.1

### DIFF
--- a/docker/graylog5.x/docker-compose.yml
+++ b/docker/graylog5.x/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: "on-failure"
 
   opensearch:
-    image: "opensearchproject/opensearch:2.4.0"
+    image: "opensearchproject/opensearch:2.4.1"
     volumes: # Stores OpenSearch data in this directory/path. Comes in handy when updating OpenSearch, so that data is retained.
       - os_data:/usr/share/opensearch/data
     environment:


### PR DESCRIPTION
Changelog is available at:

- https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-2.4.1.md

Fixes #12.