### PR TITLE
Use new Graylog Terraform Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ This Proof-of-Concept uses the following Terraform provider: <https://registry.t
     cd terraform/graylog
     ```
 
-1. To make sure you'll push the correct configuration, check all values and attributes within the modules, such as putting the `web_endpoint_uri` in [graylog.tf](/terraform/graylog/graylog.tf#L11)
+1. To make sure you'll push the correct configuration, check all values and attributes within the modules, such as putting the `web_endpoint_uri` in [graylog.tf](/terraform/graylog/graylog.tf#L11). It should look similar to `http://<domain-name-or-IP:9000/api>`
 
 1. In the same directory, you have to install the provider, which you can do by the following
 

--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ This Proof-of-Concept uses the following Terraform provider: <https://registry.t
     cd terraform/graylog
     ```
 
-1. To make sure you'll push the correct configuration, check all values and attributes within the modules.
+1. To make sure you'll push the correct configuration, check all values and attributes within the modules, such as putting the `web_endpoint_uri` in [graylog.tf](/terraform/graylog/graylog.tf#L11)
 
-1. Here you have to install the provider, which you can do by the following
+1. In the same directory, you have to install the provider, which you can do by the following
 
     ```shell
     terraform init

--- a/docker/graylog5.x/docker-compose.yml
+++ b/docker/graylog5.x/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     restart: "on-failure"
 
   graylog:
-    image: "graylog/graylog:5.0.0"
+    image: "graylog/graylog:5.0.1"
     depends_on:
       opensearch:
         condition: "service_started"

--- a/terraform/graylog/.terraform.lock.hcl
+++ b/terraform/graylog/.terraform.lock.hcl
@@ -1,21 +1,24 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/terraform-provider-graylog/graylog" {
-  version     = "1.0.4"
-  constraints = "1.0.4"
+provider "registry.terraform.io/zahiar/graylog" {
+  version     = "1.3.0"
+  constraints = "1.3.0"
   hashes = [
-    "h1:cokc8TlmgGnfLaOYiefyvy8MquQGxopRM2pEvaipsDU=",
-    "zh:3af3a4ef6d8a362ed41124c7a706101e50e4881a919cb99a39e782e93c348136",
-    "zh:40d0d4288fa3b714f4098fe2f77f282ed0db99eedb4314225ca98d320dd7b23c",
-    "zh:5c2d02e0f2a64c088d89b2a564beeeefb18e3e2e4a51cf389a873c0cbf4adea6",
-    "zh:75e1cee088b54482d4c8d9cbbec0634d0ea10207f75c0956ce9ccbe5fe5a7566",
-    "zh:77c816c3b3fd390bbf5553743165b9aab0ee9429624d84e59c8003cafeac01b1",
-    "zh:8948d8dc6ce1e434e1bec454cc30e4f14ad646ad04230a3cc9961edc816694fc",
-    "zh:bf38492df939e64952bee643cffd9e7538e4c1e1c08f6ef6eb7630188b68fc6d",
-    "zh:d8807cccf68a5bbea78284f9483e845f9a312d97f35efb46895972163f3dd805",
-    "zh:e609975d4b31d9d64c8fe440deb23c2299f2948e8d5edf2a5cbbbc21ee31063a",
-    "zh:fb07da168f6b1dd2b9cd30dc599fe28edd616c6d008c5e7fa161cc2e8fe240d5",
-    "zh:fd8ae6186bb047d16501ffb95b16ee75e14a116ec4dd30ac2dcca188b97e12f7",
+    "h1:Lf03rHNG8l9fR+PHZ7/CoNinbYZeLVPNKvVO4zW+wVw=",
+    "zh:14cf8ac241c8d36bc526a9a2a1b1df6994aebc5acc44d70c12ef23c79696865b",
+    "zh:2ef9e1ef873ad71770f3e24ded19c2831f5a1907c4e53775da4b58d9ca2e49c3",
+    "zh:4fe7162627f6f75eb2cf0f3c28714799c47d1fb00abc3ab25988f4885ad27514",
+    "zh:5c14f379eeb7264524418c42acf05992f68ece908e60b5f1e6ebd28d63bbe235",
+    "zh:6a730ac0818551ae14bb15b1d12fa2c7e437f8d2029cafb54181a0b9a529f2af",
+    "zh:77a37a94403f7a2dc17450eb69e2ab51edd8c4fe26a7e4b6efc670d437746ab2",
+    "zh:7c8af012173f2a0fc558b979abc23041b8aa93d512591702d53d29211baf1c28",
+    "zh:7cf43ccd712536dd1eada4a8f1c263c381b32884a2cab98fce3451c2f230202f",
+    "zh:95f5645332024b91a9572295d4bc035554d9503ff41056b9bc2682eff323cb55",
+    "zh:af65095e22549a380a91c204015c18540a5e093e6654e628a3f7522060d6c3f7",
+    "zh:b90d55c2a16c8b7ab205cbca74b5ebbc57ee0e2a4fb672a39a29f8e8e64aacb0",
+    "zh:c66e3d1dcf9e873df98fc4ba673c8811e135d46247128d9be16e5817e4e7baf7",
+    "zh:cf51c586cacfdcef449dd6a4e6b3579881d6c506519bb3054da859c04f39b0ad",
+    "zh:f99cf98864cae6d314f00f38377f946b71fb7ce12298e39861825e054070fb2f",
   ]
 }

--- a/terraform/graylog/alarm_callback.tf
+++ b/terraform/graylog/alarm_callback.tf
@@ -41,13 +41,13 @@ resource "graylog_event_notification" "slackip" {
 }
 
 resource "graylog_event_notification" "thehive" {
-  count = (var.enable_the_hive ? 1 : 0)
+  count       = (var.enable_the_hive ? 1 : 0)
   description = "Sends notification to The Hive"
   title       = "The Hive"
-  config      = jsonencode(
+  config = jsonencode(
     {
-      type    = "http-notification-v1",
-      url     = var.the_hive_uri # You can change the value in `terraform.tfvars`
+      type = "http-notification-v1",
+      url  = var.the_hive_uri # You can change the value in `terraform.tfvars`
     }
   )
 }

--- a/terraform/graylog/event_definition.tf
+++ b/terraform/graylog/event_definition.tf
@@ -19,14 +19,14 @@ resource "graylog_event_definition" "firewall" {
     execute_every_ms = 60000
     group_by         = []
     series           = []
-    conditions       = {
-      expression    = null
+    conditions = {
+      expression = null
     }
   })
 
   field_spec = null
 
-  key_spec   = null
+  key_spec = null
 
   # For creating a webhook with notifications being sent to Slack, see: https://api.slack.com/messaging/webhooks
 
@@ -60,8 +60,8 @@ resource "graylog_event_definition" "ip_address" {
     execute_every_ms = 60000
     group_by         = []
     series           = []
-    conditions       = {
-      expression    = null
+    conditions = {
+      expression = null
     }
   })
 

--- a/terraform/graylog/graylog.tf
+++ b/terraform/graylog/graylog.tf
@@ -1,15 +1,15 @@
 terraform {
   required_providers {
     graylog = {
-      source  = "terraform-provider-graylog/graylog"
-      version = "1.0.4"
+      source  = "zahiar/graylog"
+      version = "1.3.0"
     }
   }
 }
 
 provider "graylog" {
   web_endpoint_uri = ""
-  api_version      = "v3"
+  api_version      = "v5"
   auth_name        = var.authusername
   auth_password    = var.authpassword
 }

--- a/terraform/graylog/pipeline.tf
+++ b/terraform/graylog/pipeline.tf
@@ -7,5 +7,5 @@ resource "graylog_pipeline" "internalip" {
 
 resource "graylog_pipeline" "normalisation" {
   source      = var.normalise_firewall
-  description = "Normalises events from the firewall"  
+  description = "Normalises events from the firewall"
 }

--- a/terraform/graylog/pipeline_rule.tf
+++ b/terraform/graylog/pipeline_rule.tf
@@ -1,11 +1,11 @@
 # Creates the actual Pipeline rules with its corresponding rules and actions
 
 resource "graylog_pipeline_rule" "internalip" {
-    source      = var.internal_ip_rule
-    description = "Used for Pipelines that only process events with a destination IP field"
+  source      = var.internal_ip_rule
+  description = "Used for Pipelines that only process events with a destination IP field"
 }
 
 resource "graylog_pipeline_rule" "normalisation" {
-    source      = var.normalise_firewall_rule
-    description = "Normalises events from the firewall"
+  source      = var.normalise_firewall_rule
+  description = "Normalises events from the firewall"
 }


### PR DESCRIPTION
- Use new Graylog Terraform Provider: [the original one has been deprecated](https://github.com/terraform-provider-graylog/terraform-provider-graylog) and [a user has forked the project](https://github.com/zahiar/terraform-provider-graylog) to give it a new life, bringing some compatibility updates and added features.
- Upgrade used Graylog API (v3 -> v5)
- Update documentation regarding the `web_endpoint_uri`
- Upgrade Graylog to 5.0.1

Fixes #8.