### PR TITLE
Add environment variables for sensitive values of Graylog configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ We're making use of an Ubuntu Minimal 22.04 instance running on a hypervisor.
 
 In this repository we already have created a `docker-compose.yml`. See <https://github.com/AnonymousWP/Grayhive/blob/master/docker/docker-compose.yml> in case you didn't create one yet.
 
-**NOTE**: don't forget to change the values in `docker-compose.yml` and its corresponding `.env` file. Click [here](docker\\graylog5.x\\.env) or [here](docker\\graylog4.x\\.env) for the `.env` file.
+**NOTE**: don't forget to change the values in `docker-compose.yml` and its corresponding `.env` file. Click [here](./docker/graylog5.x/.env) or [here](./docker/graylog5.x/.env) for the `.env` file.
 
 1. Verify you have Docker Compose installed
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ We're making use of an Ubuntu Minimal 22.04 instance running on a hypervisor.
 
 In this repository we already have created a `docker-compose.yml`. See <https://github.com/AnonymousWP/Grayhive/blob/master/docker/docker-compose.yml> in case you didn't create one yet.
 
+**NOTE**: don't forget to change the values in `docker-compose.yml` and its corresponding `.env` file. Click [here](docker\\graylog5.x\\.env) or [here](docker\\graylog4.x\\.env) for the `.env` file.
+
 1. Verify you have Docker Compose installed
 
     ```shell
@@ -114,7 +116,7 @@ In this repository we already have created a `docker-compose.yml`. See <https://
     sudo docker-compose up -d
     ```
 
-    _N.B. Execute this command in the directory where the
+    Note: execute this command in the directory where the
     docker-compose.yml file is located!_
 
 1. Create input to test if log messages are received

--- a/docker/graylog4.x/.env
+++ b/docker/graylog4.x/.env
@@ -1,0 +1,2 @@
+GRAYLOG_PASSWORD_SECRET=<your-password>
+GRAYLOG_ROOT_PASSWORD_SHA2=<hash-of-the-above-password>

--- a/docker/graylog4.x/docker-compose.yml
+++ b/docker/graylog4.x/docker-compose.yml
@@ -36,9 +36,9 @@ services:
     volumes:
       - graylog_data:/usr/share/graylog/data # Stores Graylog data in this directory/path. Comes in handy when updating Graylog, so that data is retained.
     environment:
-      - GRAYLOG_PASSWORD_SECRET=EnterSaltHere # You can generate a password using `pwgen -N 1 -s 96`
+      - GRAYLOG_PASSWORD_SECRET=${GRAYLOG_PASSWORD_SECRET} # You can generate a password using `pwgen -N 1 -s 96`
 
-      - GRAYLOG_ROOT_PASSWORD_SHA2=EnterSHA2HashOfYourPasswordHere # You can generate the SHA256-hash of your password with `echo -n <password> | sha256sum`
+      - GRAYLOG_ROOT_PASSWORD_SHA2=${GRAYLOG_ROOT_PASSWORD_SHA2} # You can generate the SHA256-hash of your password with `echo -n <password> | sha256sum`
 
       - GRAYLOG_HTTP_EXTERNAL_URI=http://EnterURIHere:9000/ # You can change the IP-address to 127.0.0.1 if you want to run it locally or an external IP-address if you want to run it on a server.
 

--- a/docker/graylog5.x/.env
+++ b/docker/graylog5.x/.env
@@ -1,0 +1,2 @@
+GRAYLOG_PASSWORD_SECRET=<your-password>
+GRAYLOG_ROOT_PASSWORD_SHA2=<hash-of-the-above-password>

--- a/docker/graylog5.x/docker-compose.yml
+++ b/docker/graylog5.x/docker-compose.yml
@@ -36,8 +36,8 @@ services:
     entrypoint: "/usr/bin/tini -- wait-for-it opensearch:9200 --  /docker-entrypoint.sh"
     environment:
       GRAYLOG_NODE_ID_FILE: "/usr/share/graylog/data/config/node-id"
-      GRAYLOG_PASSWORD_SECRET: "<your-password>" # You can generate a password using `pwgen -N 1 -s 96`
-      GRAYLOG_ROOT_PASSWORD_SHA2: "<hash-of-the-above-password>" # You can generate the SHA256-hash of your password with `echo -n <password> | sha256sum`
+      GRAYLOG_PASSWORD_SECRET: ${GRAYLOG_PASSWORD_SECRET} # You can generate a password using `pwgen -N 1 -s 96`
+      GRAYLOG_ROOT_PASSWORD_SHA2: ${GRAYLOG_ROOT_PASSWORD_SHA2} # You can generate the SHA256-hash of your password with `echo -n <password> | sha256sum`
       GRAYLOG_HTTP_BIND_ADDRESS: "0.0.0.0:9000"
       GRAYLOG_HTTP_EXTERNAL_URI: "http://your-ip:9000/" # You can change the IP-address to 127.0.0.1 if you want to run it locally, and any external IP-address if you want to run it on a server.
       GRAYLOG_ELASTICSEARCH_HOSTS: "http://opensearch:9200"


### PR DESCRIPTION
For security reasons, values like the password and its corresponding SHA2-hash will now use an environment variable.