### PR TITLE
ops(`clean_start.sh`): only remove resources related to the Docker Compose file

### DIFF
--- a/docker/clean_start.sh
+++ b/docker/clean_start.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# This shell script deletes all Docker data such as containers, networks, images and volumes. In case executing this script doesn't work, allow it to execute: `sudo chmod +x ./clean_start.sh`
-
-echo "Done pruning; all resources have been removed."
-docker system prune -a -f --volumes

--- a/docker/graylog4.x/clean_start.sh
+++ b/docker/graylog4.x/clean_start.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-bold=$(tput bold)
-normal=$(tput sgr0)
+# In case executing this script doesn't work, allow it to execute: `sudo chmod +x ./clean_start.sh`
 
 # Remove containers related to the Docker Compose file
 docker compose down --rmi all
@@ -21,4 +20,4 @@ for image in $(docker images | grep 'graylog\|mongo\|opensearchproject' | awk '{
   docker rmi -f $image
 done
 
-echo "${bold}All Docker resources related to the Docker Compose file have been removed.${normal}"
+echo -e "\033[1mAll Docker resources related to the Docker Compose file have been removed.\033[0m"

--- a/docker/graylog4.x/clean_start.sh
+++ b/docker/graylog4.x/clean_start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# Remove containers related to the Docker Compose file
+docker compose down --rmi all
+
+# Remove networks related to the Docker Compose file
+for network in $(docker network ls --filter name='graylog' --format '{{.Name}}'); do
+  docker network rm $network
+done
+
+# Remove volumes related to the Docker Compose file
+for volume in $(docker volume ls --filter name='graylog' --format '{{.Name}}'); do
+  docker volume rm $volume
+done
+
+# Remove images related to the Docker Compose file
+for image in $(docker images | grep 'graylog\|mongo\|opensearchproject' | awk '{print $3}'); do
+  docker rmi -f $image
+done
+
+echo "${bold}All Docker resources related to the Docker Compose file have been removed.${normal}"

--- a/docker/graylog5.x/clean_start.sh
+++ b/docker/graylog5.x/clean_start.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-bold=$(tput bold)
-normal=$(tput sgr0)
+# In case executing this script doesn't work, allow it to execute: `sudo chmod +x ./clean_start.sh`
 
 # Remove containers related to the Docker Compose file
 docker compose down --rmi all
@@ -21,4 +20,4 @@ for image in $(docker images | grep 'graylog\|mongo\|opensearchproject' | awk '{
   docker rmi -f $image
 done
 
-echo "${bold}All Docker resources related to the Docker Compose file have been removed.${normal}"
+echo -e "\033[1mAll Docker resources related to the Docker Compose file have been removed.\033[0m"

--- a/docker/graylog5.x/clean_start.sh
+++ b/docker/graylog5.x/clean_start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# Remove containers related to the Docker Compose file
+docker compose down --rmi all
+
+# Remove networks related to the Docker Compose file
+for network in $(docker network ls --filter name='graylog' --format '{{.Name}}'); do
+  docker network rm $network
+done
+
+# Remove volumes related to the Docker Compose file
+for volume in $(docker volume ls --filter name='graylog' --format '{{.Name}}'); do
+  docker volume rm $volume
+done
+
+# Remove images related to the Docker Compose file
+for image in $(docker images | grep 'graylog\|mongo\|opensearchproject' | awk '{print $3}'); do
+  docker rmi -f $image
+done
+
+echo "${bold}All Docker resources related to the Docker Compose file have been removed.${normal}"


### PR DESCRIPTION
This makes sure when executing, you don't remove all of your Docker resources.